### PR TITLE
fix(parser): exclude empty tokens and cstRoot bug

### DIFF
--- a/src/main/java/refdiff/parsers/python/PythonPlugin.java
+++ b/src/main/java/refdiff/parsers/python/PythonPlugin.java
@@ -200,9 +200,7 @@ public class PythonPlugin implements LanguagePlugin, Closeable {
 						functionCalls= AddtoArraylist(functionCalls, temp1, node);
 					}
 
-					if(node.getType().equals(NodeType.FILE)) {
-						root.addNode(cstNode);
-					}
+					root.addNode(cstNode);
 				}
 			}
 

--- a/src/main/resources/parser.py
+++ b/src/main/resources/parser.py
@@ -20,12 +20,13 @@ def get_tokenz(node):  # pass a node and it will return the tokens
     if isinstance(node, ast.Module):
         isStart = True
         line = 0
-        a = atok.get_tokens(node, include_extra=True)
+        a = atok.get_tokens(node, include_extra=False)
         for i in a:
             if isStart:
                 line = i.start[0]
                 isStart = False
-            tokens.append("{}-{}".format(i.startpos, i.endpos))
+            if i.string.strip() and i.string != "\n": # not empty token
+                tokens.append("{}-{}".format(i.startpos, i.endpos))
         jsonData.append({
             "type": "File",
             "name": file_name[1],
@@ -34,10 +35,10 @@ def get_tokenz(node):  # pass a node and it will return the tokens
             "parent": None,
             "start": tokens[0].split('-')[0],
             "end": tokens[-1].split('-')[1],
-            "tokens": [t for t in tokens]
+            "tokens": tokens
         })
     else:
-        a = atok.get_tokens(node, include_extra=True)
+        a = atok.get_tokens(node, include_extra=False)
         isStart = True
         startToken = endToken = line = 0
         tokens.append(node.name)

--- a/src/test/java/refdiff/parsers/python/TestCstPythonParser.java
+++ b/src/test/java/refdiff/parsers/python/TestCstPythonParser.java
@@ -29,9 +29,44 @@ public class TestCstPythonParser {
 		SourceFolder sources = SourceFolder.from(basePath, Paths.get("example.py"));
 		CstRoot root = parser.parse(sources);
 		
-		assertThat(root.getNodes().size(), is(3));
+		assertThat(root.getNodes().size(), is(4));
 
 		assertThat(root.getNodes().get(0).getType(), is(NodeType.FILE));
 		assertThat(root.getNodes().get(0).getSimpleName(), is("example.py"));
-	}	
+		
+		assertThat(root.getNodes().get(1).getType(), is(NodeType.CLASS));
+		assertThat(root.getNodes().get(1).getSimpleName(), is("test"));
+		assertThat(root.getNodes().get(1).getParent().get().getSimpleName(), is("example.py"));
+		
+		assertThat(root.getNodes().get(2).getType(), is(NodeType.FUNCTION));
+		assertThat(root.getNodes().get(2).getSimpleName(), is("sum"));
+		assertThat(root.getNodes().get(1).getParent().get().getSimpleName(), is("test"));
+		
+		assertThat(root.getNodes().get(3).getType(), is(NodeType.FUNCTION));
+		assertThat(root.getNodes().get(3).getSimpleName(), is("multi"));
+		assertThat(root.getNodes().get(1).getParent().get().getSimpleName(), is("test"));
+	}
+	
+	@Test
+	public void shouldTokenizeSimpleFile() throws Exception {
+		Path basePath = Paths.get("test-data/parser/python/");
+		SourceFolder sources = SourceFolder.from(basePath, Paths.get("example.py"));
+
+		CstRoot cstRoot = parser.parse(sources);
+		CstNode sumFunction = cstRoot.getNodes().get(2);
+		String sourceCode = sources.readContent(sources.getSourceFiles().get(0));
+		
+		List<String> actual = CstRootHelper.retrieveTokens(cstRoot, sourceCode, sumFunction, false);
+		List<String> expected = Arrays.asList("def", "sum", "(", "a", ",", "b", ")", ":",
+				"c", "=", "a", "+", "b", "return", "c");
+		
+		assertArrayEquals(expected.toArray(), actual.toArray());
+		
+		CstNode multiFunction = cstRoot.getNodes().get(3);
+		actual = CstRootHelper.retrieveTokens(cstRoot, sourceCode, multiFunction, false);
+		expected = Arrays.asList("def", "multi", "(", "q", ",", "w", ")", ":",
+				"e", "=", "q", "*", "w", "return", "e");
+
+		assertArrayEquals(expected.toArray(), actual.toArray());
+	}
 }


### PR DESCRIPTION
- I converted the parser to unix format, to support Windows + Linux + Mac
- `root.addNode(cstNode);` should be called to all CST Nodes.
- I include some unit tests to validate the parser.
- I also excluded all empty tokens, such as empty spaces, end lines (it affects the precision and recall)

One test failed:
![image](https://user-images.githubusercontent.com/7620947/113452795-230b5c00-93db-11eb-8ce1-75905eeab580.png)

For the example in the `test-data/parser/python/example.py`, the parent of the function `sum` and `multi` must be the class `test` and not `example.py`, right? 