### PR TITLE
fix(parser): include params in function signature

### DIFF
--- a/src/main/java/refdiff/parsers/python/Node.java
+++ b/src/main/java/refdiff/parsers/python/Node.java
@@ -187,32 +187,11 @@ public class Node {
 			return positions;
 		}
 
-//		Map<Integer, Integer> linePositionOffset = new HashMap<>();
-//		linePositionOffset.put(0, 0);
-//		int lineNumber = 1;
-//		String[] lines = content.split(System.lineSeparator());
-//		for (String line: lines) {
-//			linePositionOffset.put(lineNumber, linePositionOffset.get(lineNumber-1) + line.length() + System.lineSeparator().length());
-//			lineNumber++;
-//		}
-
-
 		for(String token: this.tokens) {
 			String[] parts = token.split("-");
 
 			int start = Integer.parseInt(parts[0]);
 			int end = Integer.parseInt(parts[1]);
-
-//			int line = Integer.parseInt(parts[0]);
-//			int column = Integer.parseInt(parts[1]);
-//			int size = Integer.parseInt(parts[2]);
-//
-//			if (line >= lines.length){
-//				System.out.println("eita!");
-//			}
-//
-//			int startPosition = linePositionOffset.get(line) + column;
-//			int endPosition = startPosition + size;
 
 			positions.add(new TokenPosition(start, end));
 		}

--- a/src/main/java/refdiff/parsers/python/PythonPlugin.java
+++ b/src/main/java/refdiff/parsers/python/PythonPlugin.java
@@ -189,7 +189,7 @@ public class PythonPlugin implements LanguagePlugin, Closeable {
 					if (node.getParent() != null) {
 						node.setNamespace(null);
 						// initialize if key not present
-						childrenByAddress= AddtoArraylist(childrenByAddress, temp1, node);
+						childrenByAddress = AddtoArraylist(childrenByAddress, temp1, node);
 					}
 
 					// save call graph information
@@ -282,7 +282,7 @@ public class PythonPlugin implements LanguagePlugin, Closeable {
 		}
 
 		if (node.getType().equals(NodeType.FUNCTION)) {
-			String localName = String.format("%s(%s)", node.getName(), String.join(",", node.getParameterTypes()));
+			String localName = String.format("%s(%s)", node.getName(), String.join(",", node.getParametersNames()));
 			if (node.getReceiver() != null && !node.getReceiver().isEmpty()) {
 				localName = String.format("%s.%s", node.getReceiver(), localName);
 			}
@@ -296,10 +296,8 @@ public class PythonPlugin implements LanguagePlugin, Closeable {
 
 	@Override
 	public FilePathFilter getAllowedFilesFilter() {
-		List<String> ignoreFiles = Arrays.asList("");
 		return new FilePathFilter(Arrays.asList(".py"));
 	}
-
 
 	@Override
 	public void close() {}

--- a/src/test/java/refdiff/parsers/python/TestCstPythonParser.java
+++ b/src/test/java/refdiff/parsers/python/TestCstPythonParser.java
@@ -15,8 +15,6 @@ import refdiff.core.cst.CstNode;
 import refdiff.core.cst.CstRoot;
 import refdiff.core.diff.CstRootHelper;
 import refdiff.core.io.SourceFolder;
-import refdiff.parsers.python.NodeType;
-import refdiff.parsers.python.PythonPlugin;
 import refdiff.test.util.PythonParserSingleton;
 
 public class TestCstPythonParser {
@@ -46,12 +44,18 @@ public class TestCstPythonParser {
 		CstNode sumFunctionNode = classNode.getNodes().get(0);
 		assertThat(sumFunctionNode.getType(), is(NodeType.FUNCTION));
 		assertThat(sumFunctionNode.getSimpleName(), is("sum"));
-		assertThat(sumFunctionNode.getParent(), is(classNode));
+		assertThat(sumFunctionNode.getLocalName(), is("sum(a,b)"));
+		assertThat(sumFunctionNode.getParameters().get(0).getName(), is("a"));
+		assertThat(sumFunctionNode.getParameters().get(1).getName(), is("b"));
+		assertThat(sumFunctionNode.getParent().get().getLocalName(), is(classNode.getLocalName()));
 
 		CstNode multiFunctionNode = classNode.getNodes().get(1);
 		assertThat(multiFunctionNode.getType(), is(NodeType.FUNCTION));
 		assertThat(multiFunctionNode.getSimpleName(), is("multi"));
-		assertThat(multiFunctionNode.getParent(), is(classNode));
+		assertThat(multiFunctionNode.getLocalName(), is("multi(q,w)"));
+		assertThat(multiFunctionNode.getParameters().get(0).getName(), is("q"));
+		assertThat(multiFunctionNode.getParameters().get(1).getName(), is("w"));
+		assertThat(multiFunctionNode.getParent().get().getLocalName(), is(classNode.getLocalName()));
 	}
 	
 	@Test


### PR DESCRIPTION
Hi @Mosallamy,

- I fixed the unit tests
- Change the function signatures to include parameters names
- I removed some dead codes

Now the output is:
```
Refactorings from commit 78491ab088ed6752a8ac32725680e4eb797c8042 1617381042 ----sp
MOVE	{Function printIsEven(self,value) at calculator.py:9}	{Function printIsEven(value) at main.py:5})
Refactorings from commit a60eae5237655a7c0c5bc90918c1778ef23421f6 1617380993 ----sp
RENAME	{Function sum(self,a,b) at calculator.py:3}	{Function summary(self,a,b) at calculator.py:3})
RENAME	{Function mult(self,a,b) at calculator.py:6}	{Function multiply(self,a,b) at calculator.py:6})
```